### PR TITLE
Bug Fix: remap indices of resample_data to original data when using resample_proportion

### DIFF
--- a/consensusClustering.py
+++ b/consensusClustering.py
@@ -68,8 +68,10 @@ class ConsensusCluster:
                 Mh = self.cluster_(n_clusters=k).fit_predict(resample_data)
                 # find indexes of elements from same clusters with bisection
                 # on sorted array => this is more efficient than brute force search
-                id_clusts = np.argsort(Mh)
-                sorted_ = Mh[id_clusts]
+                index_mapping = np.array((Mh, resampled_indices)).T
+                index_mapping = index_mapping[index_mapping[:, 0].argsort()]
+                sorted_ = index_mapping[:, 0]
+                id_clusts = index_mapping[:, 1]
                 for i in range(k):  # for each cluster
                     ia = bisect.bisect_left(sorted_, i)
                     ib = bisect.bisect_right(sorted_, i)


### PR DESCRIPTION
When using a `resample_proportion < 1` and `AgglomerativeClustering`, the calculated consensus matrices for the optimal number of clusters `k` ends up with a block of rows and columns which are 0. As seen in the following image, these are the `1 - resample_proportion` percentage of the columns and rows at the end of the data.
<img width="360" alt="consensus_matrix" src="https://user-images.githubusercontent.com/33027697/122198517-831d8480-ce99-11eb-8bf6-bbc18ceca8a5.png">

I believe I was able to track down the bug to the part of the script, where the indices of the resampled data are used to increment `Mk[i_]`. 
In my opinion, these should however be the original indices which have to be remapped after clustering.

The PR suggests a quick fix for that by reassigning the original indices to the resampled data.

Code to reproduce the error:
```python
import numpy as np
from sklearn.cluster import AgglomerativeClustering
from ConsensusClustering import ConsensusCluster

c = ConsensusCluster(AgglomerativeClustering, 2, 50, 50, 0.8)
c.fit(data)

# Plot consensus matrix
df = pd.DataFrame(c.Mk[c.bestK])
sns.heatmap(df)
```